### PR TITLE
Factory support

### DIFF
--- a/src/DependencyInjection/Compiler/TurnOnAutowireCompilerPass.php
+++ b/src/DependencyInjection/Compiler/TurnOnAutowireCompilerPass.php
@@ -29,7 +29,7 @@ final class TurnOnAutowireCompilerPass implements CompilerPassInterface
     public function process(ContainerBuilder $containerBuilder)
     {
         foreach ($containerBuilder->getDefinitions() as $definition) {
-            if ($this->definitionAnalyzer->shouldDefinitionBeAutowired($definition)) {
+            if ($this->definitionAnalyzer->shouldDefinitionBeAutowired($containerBuilder, $definition)) {
                 $definition->setAutowired(true);
             }
         }

--- a/src/DependencyInjection/Definition/DefinitionAnalyzer.php
+++ b/src/DependencyInjection/Definition/DefinitionAnalyzer.php
@@ -29,6 +29,18 @@ final class DefinitionAnalyzer
             return false;
         }
 
+        $isFactory = $definition->getFactory() !== NULL;
+
+        if ($isFactory) {
+            return false;
+
+        } else {
+            return $this->shouldClassDefinitionBeAutowired($definition);
+        }
+    }
+
+    private function shouldClassDefinitionBeAutowired(Definition $definition) : bool
+    {
         $classReflection = new ReflectionClass($definition->getClass());
         if (!$classReflection->hasMethod('__construct') || !$this->hasConstructorArguments($classReflection)) {
             return false;

--- a/src/DependencyInjection/Definition/DefinitionAnalyzer.php
+++ b/src/DependencyInjection/Definition/DefinitionAnalyzer.php
@@ -35,7 +35,7 @@ final class DefinitionAnalyzer
         }
 
         $constructorReflection = $classReflection->getConstructor();
-        if ($this->areAllConstructorArgumentsRequired($definition, $constructorReflection)) {
+        if ($this->areAllMethodArgumentsRequired($definition, $constructorReflection)) {
             return false;
         }
 
@@ -56,7 +56,7 @@ final class DefinitionAnalyzer
         return false;
     }
 
-    private function areAllConstructorArgumentsRequired(
+    private function areAllMethodArgumentsRequired(
         Definition $definition,
         ReflectionMethod $constructorReflection
     ) : bool {

--- a/tests/DependencyInjection/Definition/DefinitionAnalyzerSource/EmptyConstructorFactory.php
+++ b/tests/DependencyInjection/Definition/DefinitionAnalyzerSource/EmptyConstructorFactory.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symplify\DefaultAutowire\Tests\DependencyInjection\Definition\DefinitionAnalyzerSource;
+
+final class EmptyConstructorFactory
+{
+    public function create() : EmptyConstructor
+    {
+        return new EmptyConstructor();
+    }
+}

--- a/tests/DependencyInjection/Definition/DefinitionAnalyzerSource/MissingArgumentsTypehintsFactory.php
+++ b/tests/DependencyInjection/Definition/DefinitionAnalyzerSource/MissingArgumentsTypehintsFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Symplify\DefaultAutowire\Tests\DependencyInjection\Definition\DefinitionAnalyzerSource;
+
+use Symplify\DefaultAutowire\Tests\Source\SomeService;
+
+final class MissingArgumentsTypehintsFactory
+{
+    /**
+     * @param string $valueWithoutType
+     * @param SomeService|null $someService
+     * @param int $value
+     *
+     * @return MissingArgumentsTypehints
+     */
+    public function create($valueWithoutType, SomeService $someService = null, $value = 1) : MissingArgumentsTypehints
+    {
+        return new MissingArgumentsTypehints($valueWithoutType, $someService, $value);
+    }
+}

--- a/tests/DependencyInjection/Definition/DefinitionAnalyzerSource/NotMissingArgumentsTypehintsFactory.php
+++ b/tests/DependencyInjection/Definition/DefinitionAnalyzerSource/NotMissingArgumentsTypehintsFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Symplify\DefaultAutowire\Tests\DependencyInjection\Definition\DefinitionAnalyzerSource;
+
+use Symplify\DefaultAutowire\Tests\Source\SomeService;
+
+final class NotMissingArgumentsTypehintsFactory
+{
+    /**
+     * @param SomeService $someService
+     * @param SomeService $anotherService
+     *
+     * @return NotMissingArgumentsTypehints
+     */
+    public function create(SomeService $someService, SomeService $anotherService) : NotMissingArgumentsTypehints
+    {
+        return new NotMissingArgumentsTypehints($someService, $anotherService);
+    }
+}

--- a/tests/Resources/config/config.yml
+++ b/tests/Resources/config/config.yml
@@ -23,6 +23,19 @@ services:
         arguments:
             - '@some_service'
 
+    some_built_autowired_service_factory:
+        class: Symplify\DefaultAutowire\Tests\Source\SomeBuiltAutowiredServiceFactory
+
+    some_built_autowired_service:
+        class: Symplify\DefaultAutowire\Tests\Source\SomeBuiltAutowiredService
+        factory: ['@some_built_autowired_service_factory', 'create']
+
+    some_built_service_with_optional_dependencies:
+        class: Symplify\DefaultAutowire\Tests\Source\SomeServiceWithOptionalConstructorArguments
+        factory:
+            - Symplify\DefaultAutowire\Tests\Source\SomeServiceWithOptionalConstructorArgumentsFactory
+            - 'create'
+
 doctrine:
     orm:
     dbal:

--- a/tests/Source/SomeBuiltAutowiredService.php
+++ b/tests/Source/SomeBuiltAutowiredService.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Symplify\DefaultAutowire\Tests\Source;
+
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class SomeBuiltAutowiredService
+{
+    /**
+     * @var SomeService
+     */
+    private $someService;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    public function __construct(SomeService $someService, EventDispatcherInterface $eventDispatcher)
+    {
+        $this->someService = $someService;
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    /**
+     * @return SomeService
+     */
+    public function getSomeService() : SomeService
+    {
+        return $this->someService;
+    }
+
+    /**
+     * @return EventDispatcherInterface
+     */
+    public function getEventDispatcher() : EventDispatcherInterface
+    {
+        return $this->eventDispatcher;
+    }
+}

--- a/tests/Source/SomeBuiltAutowiredServiceFactory.php
+++ b/tests/Source/SomeBuiltAutowiredServiceFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Symplify\DefaultAutowire\Tests\Source;
+
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class SomeBuiltAutowiredServiceFactory
+{
+    /**
+     * @param SomeService $someService
+     * @param EventDispatcherInterface $eventDispatcher
+     *
+     * @return SomeBuiltAutowiredService
+     */
+    public function create(
+        SomeService $someService,
+        EventDispatcherInterface $eventDispatcher
+    ) : SomeBuiltAutowiredService {
+        return new SomeBuiltAutowiredService($someService, $eventDispatcher);
+    }
+}

--- a/tests/Source/SomeServiceWithOptionalConstructorArgumentsFactory.php
+++ b/tests/Source/SomeServiceWithOptionalConstructorArgumentsFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Symplify\DefaultAutowire\Tests\Source;
+
+class SomeServiceWithOptionalConstructorArgumentsFactory
+{
+    /**
+     * @param SomeService|null $someService
+     * @param array $arg
+     *
+     * @return SomeServiceWithOptionalConstructorArguments
+     */
+    public function create(
+        SomeService $someService = null,
+        array $arg = []
+    ) : SomeServiceWithOptionalConstructorArguments {
+        return new SomeServiceWithOptionalConstructorArguments($someService, $arg);
+    }
+}


### PR DESCRIPTION
Adds support for services created by a factory, eg.

```
factory:
    class: Factory

built_service:
    class: Service
    factory: ['@factory', 'create']
```

Currently the `DefaultAnalyzer` would analyze `built_service` based on the constructor of `Service` rather than on the factory method `Factory::create`.

Unfortunately my code doesn't pass one CS check but I'm unsure how to fix it. Issue concers lines with `use` clause.

```
FILE: .../tests/DependencyInjection/Definition/DefinitionAnalyzerTest.php
----------------------------------------------------------------------
pick 321bc39 rename DefinitionAnalyzer::areAllConstructorMethodArgumentsRequired to more fitting areAllMethodArgumentsRequired
FOUND 2 ERRORS AFFECTING 2 LINES
----------------------------------------------------------------------
 14 | ERROR | Line exceeds maximum limit of 120 characters; contains 124
    |       | characters (Generic.Files.LineLength.MaxExceeded)
 16 | ERROR | Line exceeds maximum limit of 120 characters; contains 127
    |       | characters (Generic.Files.LineLength.MaxExceeded)
----------------------------------------------------------------------
```
